### PR TITLE
 Support more custom types

### DIFF
--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -6,11 +6,22 @@ describe("testing extended expect", () => {
 		expect("").toBeType("string");
 		expect({}).toBeType("object");
 		expect(1).toBeType("number");
+		expect(false).toBeType("boolean");
+		expect(Symbol('foobar')).toBeType("symbol");
+		expect(() => {}).toBeType("function");
 	});
-	it("tests array types correctly", () => {
+	it("tests other types correctly", () => {
 		expect([]).toBeType("array");
+		expect(/foobar/).toBeType("regexp");
+		expect(new RegExp('foobar')).toBeType("regexp");
+		expect(null).toBeType("null");
+		expect(undefined).toBeType("undefined");
+		expect(new Map()).toBeType("map");
+		expect(new Set()).toBeType("set");
+		// https://github.com/facebook/jest/pull/4621
+		// expect(new Date()).toBeType("date");
 	});
 	it("works with promises", () => {
-		expect(Promise.resolve([])).resolves.toBeType("array");
+		return expect(Promise.resolve([])).resolves.toBeType("array");
 	});
 });

--- a/index-cjs.js
+++ b/index-cjs.js
@@ -1,6 +1,7 @@
+const getType = require('jest-get-type');
+
 const toBeType = (received, argument) => {
-	const initialType = typeof received;
-	const type = initialType === "object" ? Array.isArray(received) ? "array" : initialType : initialType;
+	const type = getType(received);
 	return type === argument ? {
 		message: () => `expected ${received} to be type ${argument}`,
 		pass: true

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
+import getType from "jest-get-type";
+
 exports const toBeType => (received, argument) {
-	const initialType = typeof received;
-	const type = initialType === "object" ? Array.isArray(received) ? "array" : initialType : initialType;
+	const type = getType(received);
 	return type === argument ? {
 		message: () => `expected ${received} to be type ${argument}`,
 		pass: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -2459,8 +2459,7 @@
     "jest-get-type": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
-      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
-      "dev": true
+      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q=="
     },
     "jest-haste-map": {
       "version": "21.2.0",

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   "homepage": "https://github.com/abritinthebay/jest-tobetype#readme",
   "devDependencies": {
     "jest": "^21.2.1"
+  },
+  "dependencies": {
+    "jest-get-type": "^21.2.0"
   }
 }


### PR DESCRIPTION
Lot's of things resolves to `object` when you do `typeof`, not just array. This adds support for them by using jest's own module for it