### PR TITLE
Use matcher utils for prettier error messages

### DIFF
--- a/index-cjs.js
+++ b/index-cjs.js
@@ -1,13 +1,29 @@
-const toBeType = (received, argument) => {
+const { matcherHint, printExpected, printReceived } = require('jest-matcher-utils');
+
+const toBeType = (received, expected) => {
 	const initialType = typeof received;
 	const type = initialType === "object" ? Array.isArray(received) ? "array" : initialType : initialType;
-	return type === argument ? {
-		message: () => `expected ${received} to be type ${argument}`,
-		pass: true
-	} : {
-		message: () => `expected ${received} to be type ${argument}`,
-		pass: false
-	};
+
+	const pass = type === expected;
+	const message = pass
+		? () =>
+			matcherHint('.not.toBeType', 'value', 'type') +
+			'\n\n' +
+			`Expected value to be of type:\n` +
+			`  ${printExpected(expected)}\n` +
+			`Received:\n` +
+			`  ${printReceived(received)}\n`
+		: () =>
+			matcherHint('.toBeType', 'value', 'type') +
+			'\n\n' +
+			`Expected value to be of type:\n` +
+			`  ${printExpected(expected)}\n` +
+			`Received:\n` +
+			`  ${printReceived(received)}\n` +
+			`type:\n` +
+			`  ${printReceived(type)}`;
+
+	return { pass, message }
 };
 
 const wrapped = {

--- a/index.js
+++ b/index.js
@@ -1,13 +1,29 @@
-exports const toBeType => (received, argument) {
+import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
+
+export const toBeType => (received, expected) {
 	const initialType = typeof received;
 	const type = initialType === "object" ? Array.isArray(received) ? "array" : initialType : initialType;
-	return type === argument ? {
-		message: () => `expected ${received} to be type ${argument}`,
-		pass: true
-	} : {
-		message: () => `expected ${received} to be type ${argument}`,
-		pass: false
-	};
+
+	const pass = type === expected;
+	const message = pass
+		? () =>
+			matcherHint('.not.toBeType', 'value', 'type') +
+			'\n\n' +
+			`Expected value to be of type:\n` +
+			`  ${printExpected(expected)}\n` +
+			`Received:\n` +
+			`  ${printReceived(received)}\n`
+		: () =>
+			matcherHint('.toBeType', 'value', 'type') +
+			'\n\n' +
+			`Expected value to be of type:\n` +
+			`  ${printExpected(expected)}\n` +
+			`Received:\n` +
+			`  ${printReceived(received)}\n` +
+			`type:\n` +
+			`  ${printReceived(type)}`;
+
+	return { pass, message }
 };
 
 const wrapped = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
       "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-      "dev": true,
       "requires": {
         "color-convert": "1.9.0"
       }
@@ -510,7 +509,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
       "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
@@ -560,7 +558,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -568,8 +565,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
       "version": "1.0.5",
@@ -747,8 +743,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.9.0",
@@ -1991,8 +1986,7 @@
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-      "dev": true
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "hawk": {
       "version": "6.0.2",
@@ -2459,8 +2453,7 @@
     "jest-get-type": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
-      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
-      "dev": true
+      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q=="
     },
     "jest-haste-map": {
       "version": "21.2.0",
@@ -2496,7 +2489,6 @@
       "version": "21.2.1",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz",
       "integrity": "sha512-kn56My+sekD43dwQPrXBl9Zn9tAqwoy25xxe7/iY4u+mG8P3ALj5IK7MLHZ4Mi3xW7uWVCjGY8cm4PqgbsqMCg==",
-      "dev": true,
       "requires": {
         "chalk": "2.1.0",
         "jest-get-type": "21.2.0",
@@ -3243,7 +3235,6 @@
       "version": "21.2.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
       "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
-      "dev": true,
       "requires": {
         "ansi-regex": "3.0.0",
         "ansi-styles": "3.2.0"
@@ -3252,8 +3243,7 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         }
       }
     },
@@ -3697,7 +3687,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
       "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-      "dev": true,
       "requires": {
         "has-flag": "2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   "homepage": "https://github.com/abritinthebay/jest-tobetype#readme",
   "devDependencies": {
     "jest": "^21.2.1"
+  },
+  "dependencies": {
+    "jest-matcher-utils": "^21.2.1"
   }
 }


### PR DESCRIPTION
This gives actionable error messages.

With this failing test:
```js
expect([1]).toBeType("string");
```

Master:
![image](https://user-images.githubusercontent.com/1404810/31306129-b0caefca-ab49-11e7-8db7-2ecce7512005.png)

This branch:
![image](https://user-images.githubusercontent.com/1404810/31306142-f86c3c9e-ab49-11e7-8b7e-eba8916b063e.png)