### PR TITLE
fix import line in basic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Then include in your tests either in the test file you want *or* in the setup fi
 The simplest way is:
 
 ```javascript
-import toBeType from "jest-tobetype";
+import {toBeType} from "jest-tobetype";
 expect.extend({toBeType});
 ```
 This is *probably* all you'll need to do if you're not doing anything special but if you want more options - read one.


### PR DESCRIPTION
If you follow the current guide, you will see the following error.

```sh
Determining test suites to run...
Found 1 test suites
    ✘ getClientConfig > getClientConfig works '(26 ms)
  ● getClientConfig › getClientConfig works

    TypeError: matcher.apply is not a function

      36 |     const [err,config] = await to(getClientConfig())
      37 |     expect(err).toBeNull()
    > 38 |     expect(config.showLayout).toBeType('boolean')
         |                               ^
      39 |   })
      40 | })
      41 |

      at Object.throwingMatcher [as toBeType] (node_modules/expect/build/index.js:320:33)
      at Object.toBeType (__tests__/core__client__index.test.js:38:31)
      at tryCatch (node_modules/regenerator-runtime/runtime.js:62:40)
      at Generator.invoke [as _invoke] (node_modules/regenerator-runtime/runtime.js:288:22)
      at Generator.prototype.(anonymous function) [as next] (node_modules/regenerator-runtime/runtime.js:114:21)
      at asyncGeneratorStep (__tests__/core__client__index.test.js:37:103)
      at _next (__tests__/core__client__index.test.js:39:194)
```