### PR TITLE
Feature: enables 'setupFilesAfterEnv' in jest config file

### DIFF
--- a/index-cjs.js
+++ b/index-cjs.js
@@ -1,39 +1,45 @@
-const { matcherHint, printExpected, printReceived } = require('jest-matcher-utils');
-const getType = require('jest-get-type');
+const {
+  matcherHint,
+  printExpected,
+  printReceived,
+} = require("jest-matcher-utils");
+const getType = require("jest-get-type");
 
 const toBeType = (received, expected) => {
-	const type = getType(received);
-	const pass = type === expected;
-	const message = pass
-		? () =>
-			matcherHint('.not.toBeType', 'value', 'type') +
-			'\n\n' +
-			`Expected value to be of type:\n` +
-			`  ${printExpected(expected)}\n` +
-			`Received:\n` +
-			`  ${printReceived(received)}\n`
-		: () =>
-			matcherHint('.toBeType', 'value', 'type') +
-			'\n\n' +
-			`Expected value to be of type:\n` +
-			`  ${printExpected(expected)}\n` +
-			`Received:\n` +
-			`  ${printReceived(received)}\n` +
-			`type:\n` +
-			`  ${printReceived(type)}`;
+  const type = getType(received);
+  const pass = type === expected;
+  const message = pass
+    ? () =>
+        matcherHint(".not.toBeType", "value", "type") +
+        "\n\n" +
+        `Expected value to be of type:\n` +
+        `  ${printExpected(expected)}\n` +
+        `Received:\n` +
+        `  ${printReceived(received)}\n`
+    : () =>
+        matcherHint(".toBeType", "value", "type") +
+        "\n\n" +
+        `Expected value to be of type:\n` +
+        `  ${printExpected(expected)}\n` +
+        `Received:\n` +
+        `  ${printReceived(received)}\n` +
+        `type:\n` +
+        `  ${printReceived(type)}`;
 
-	return { pass, message }
+  return { pass, message };
 };
 
 const wrapped = {
-	toBeType
+  toBeType,
 };
 
 const extend = (expect) => {
-	expect.extend(wrapped);
+  expect.extend(wrapped);
 };
 
 exports.toBeType = toBeType;
 exports.extend = extend;
 exports.default = wrapped; // es6 compat
 module.exports = wrapped;
+
+expect.extend({ toBeType });

--- a/index-cjs.js
+++ b/index-cjs.js
@@ -42,4 +42,5 @@ exports.extend = extend;
 exports.default = wrapped; // es6 compat
 module.exports = wrapped;
 
+// THIS ENABLES 'setupFilesAfterEnv' in jest config file
 expect.extend({ toBeType });


### PR DESCRIPTION
## 📌 Feature

### issue:
 
[issue #18](https://github.com/abritinthebay/jest-tobetype/issues/16#issue-661548844)

This will make as follow:

```javascript
// jest.config.js

module.exports = {
  setupFilesAfterEnv: ["jest-tobetype"],
};
```
which enables user not importing in every files.